### PR TITLE
:+1:Python code for ST-FMR analysis

### DIFF
--- a/src/STFMR/curvefitting/__init__.py
+++ b/src/STFMR/curvefitting/__init__.py
@@ -1,0 +1,1 @@
+from .core import CurveFitting, CurvePlotting

--- a/src/STFMR/curvefitting/core.py
+++ b/src/STFMR/curvefitting/core.py
@@ -1,0 +1,158 @@
+import scipy.optimize as sopt
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+
+import sys
+import glob
+import re
+
+from setting import *
+from rootcommand import CommonOption, RootCommand
+from uroboros import Command
+from uroboros.constants import ExitStatus
+
+fitting_range = {
+    "positive": list(range(610, 1190)),
+    "negative": list(range(10, 590))
+}
+Fontsize = 12
+
+
+def fitfunc_curve(h, hr, s, a, w, c, d):
+    """
+        DC電圧の波形の関数．
+
+         Parameters
+        ----------
+        h : float
+            印加磁場
+        hr : float
+            共鳴磁場
+        s : float
+            symmetry成分の振幅
+        a : float
+            antisymmetry成分の振幅
+        w : float
+            線幅
+        c : float
+            線型部分の傾き
+        d : float
+            線型部分の切片
+        """
+    return s * w * w / ((h - hr) * (h - hr) + w * w) + a * w * (h - hr) / ((h - hr)*(h - hr) + w*w) + c*h + d
+
+
+class CurveFitting(Command):
+    """Sub command of root"""
+    name = 'curve'
+    options = [CommonOption()]
+
+    short_description = 'ST-FMR fitting for a single sample'
+    long_description = 'Analyze experimental data using ST-FMR method for a single sample'
+    file_list = []
+
+    # 正側と負側のフィッティング範囲
+
+    range_type = []
+    frequency = []
+    h_res = []
+    sym = []
+    asym = []
+    linewidth = []
+    slope = []
+    bias = []
+    columns = ["range_type", "frequency", "h_res", "sym",
+               "asym", "linewidth", "slope", "bias"]
+
+    def file_parser(self, foldername):
+        filename = glob.glob(foldername + '/*lvm')  # lvmファイルがあるフォルダー内のファイル名を取得
+        if filename == []:
+            return ExitStatus.MISS_USAGE
+
+        for i, filename in enumerate(filename):
+            # ファイル名から周波数部分だけ抽出
+            pat = r'[0-9]+\.[0-9]+'  # 抽出するパターン：数字
+            num_list = re.findall(pat, filename)  # 数字を抽出してリスト化
+            fre = float(num_list[0])
+            self.file_list.append([fre, filename])
+        self.file_list.sort(key=lambda x: x[0])
+
+    def curve_fitting(self, fre, filename):
+        df = pd.read_table(filename, names=['MF', 'Vol'])
+        x = df['MF']
+        y = df['Vol']
+        for [range_type, fre_slope, fre_bias] in [["positive", 17, -17], ["negative", -17, 17]]:
+            para_ini = [fre_slope * fre + fre_bias, 1.0, 1.0, 5.0, 1.0, 1.0]
+            x_ = x[fitting_range.get(range_type)]
+            y_ = y[fitting_range.get(range_type)]
+            # フィッティングパラメータの最適化
+            para, _ = sopt.curve_fit(
+                fitfunc_curve, x_, y_, para_ini)
+            self.range_type += [range_type]
+            self.frequency += [fre]
+            self.h_res += [para[0]]
+            self.sym += [para[1]]
+            self.asym += [para[2]]
+            self.linewidth += [para[3]]
+            self.slope += [para[4]]
+            self.bias += [para[5]]
+        return 0
+
+    def run(self, args):
+        foldername = str(args.dir)
+        self.file_parser(foldername)
+        print('Target files:')
+        for fre, filename in self.file_list:
+            print(filename)
+            self.curve_fitting(fre, filename)
+        df = pd.DataFrame(
+            data={"range_type": self.range_type,
+                  "frequency": self.frequency,
+                  "h_res": self.h_res,
+                  "sym": self.sym,
+                  "asym": self.asym,
+                  "linewidth": self.linewidth,
+                  "slope": self.slope,
+                  "bias": self.bias,
+                  },
+            columns=self.columns
+        )
+        print(df)
+        df.to_csv(foldername + "/" + curve_fitting_file, index=False)
+        return ExitStatus.SUCCESS
+
+
+class CurvePlotting(Command):
+    """Sub command of stfmr"""
+    name = 'curveplot'
+    options = [CommonOption()]
+
+    short_description = 'ST-FMR Plotting for a single sample'
+    long_description = 'Generate plottings of experimental data and fitting ones.'
+
+    def run(self, args):
+        df = pd.read_csv(str(args.dir) + "/" +
+                         curve_fitting_file)
+        df = df.set_index(["range_type"], drop=True)
+        reprod_range = {
+            "positive": np.arange(0, 250, 0.5),
+            "negative": np.arange(-250, 0, 0.5)
+        }
+        for range_type in ["negative", "positive"]:
+            df_val = df.loc[(range_type)]
+            for index, row in df_val.iterrows():
+                h = reprod_range[range_type]
+                fre = row.to_list()[0]
+                para = row.to_list()[1:]
+                v = list(map(lambda x: fitfunc_curve(x, *para), h))
+                plt.plot(h, v, linewidth=2.0)
+        plt.xticks(fontsize=Fontsize)
+        plt.yticks(fontsize=Fontsize)
+        plt.grid(True)
+        plt.title("Curve fitting" + " (" + range_type + ") ")
+        plt.xlabel('magnetic field (mT)', fontsize=Fontsize)
+        plt.ylabel('voltage (V)', fontsize=Fontsize)
+        plt.savefig(str(args.dir) +
+                    "/fitting_result.png")
+        return ExitStatus.SUCCESS

--- a/src/STFMR/kittellinefitting/__init__.py
+++ b/src/STFMR/kittellinefitting/__init__.py
@@ -1,0 +1,1 @@
+from .core import KittelLineFitting

--- a/src/STFMR/kittellinefitting/core.py
+++ b/src/STFMR/kittellinefitting/core.py
@@ -1,0 +1,93 @@
+import pandas as pd
+import numpy as np
+import scipy.optimize as sopt
+import scipy.constants as sconst
+import os
+from pathlib import Path
+
+from setting import *
+from rootcommand import CommonOption, RootCommand
+from uroboros import Command
+from uroboros.constants import ExitStatus
+
+gamma = sconst.physical_constants["electron gyromag. ratio"][0]
+gamma_GHZ = float(
+    sconst.physical_constants["electron gyromag. ratio in MHz/T"][0])/1000
+
+
+def fitfunc_kittel(h, Meff):
+    """
+    面内に磁場をかけた時のKittelの式．
+
+     Parameters
+    ----------
+    h : 印加磁場 (mT)
+    gamma : 磁気回転比
+    Meff : 有効磁化
+     Output
+    ---------
+    frequency (GHz)
+    """
+    return gamma_GHZ * np.sqrt(h / 1000 * (h / 1000 + Meff))
+
+
+def fitfunc_line(x, a, b):
+    return a * x + b
+
+
+class KittelLineFitting(Command):
+    """Sub command of stfmr"""
+    name = 'kittelline'
+    options = [CommonOption()]
+
+    short_description = 'Kittel & linewidth fitting for a single sample'
+    long_description = 'Calculate Kittel & linewidth fitting and outputs effective magnetization, damping coefficient, and W0.'
+
+    def build_option(self, parser):
+        """
+        引数の追加．
+        """
+#        parser.add_argument('output', type=Path,
+#                            help="Directory to save the result data")
+        parser.add_argument('theta', type=float,
+                            help="Angle (deg) of the applied magnetic field (in-plane)")
+        parser.add_argument('df', type=float,
+                            help="Thickness (nm) of the ferromagnet")
+        parser.add_argument('dn', type=float,
+                            help="Thickness (nm) of the nonmagnet")
+        # 追加した後にparserを返す
+        return parser
+
+    def run(self, args):
+        df = pd.read_csv(str(args.dir) + "/" +
+                         curve_fitting_file)
+        df = df.set_index(["range_type"], drop=True)
+        df_result = pd.DataFrame(index=[],
+                                 columns=['range_type', 'M_eff', 'damping', 'W0', 'theta', 'df', 'dn'])
+
+        for range_type, init_M in [["negative", -0.500], ["positive", 0.500]]:
+           # load csv
+            df_val = df.loc[(range_type)]
+            h_res = df_val["h_res"].values.tolist()
+            freq = df_val["frequency"].values.tolist()
+            lw = df_val["linewidth"].values.tolist()
+
+            # Kittel fitting
+            para_ini_kittel = [init_M]
+            [para_opt_kittel, cov] = sopt.curve_fit(
+                fitfunc_kittel, h_res, freq, para_ini_kittel)
+
+            # linewidth fitting
+            para_ini_line = [2, 0.1]
+            [para_opt_line, cov] = sopt.curve_fit(
+                fitfunc_line, freq, lw, para_ini_line)
+
+            # 線幅の単位はmT
+            alpha = (para_opt_line[0] * gamma_GHZ)/1000
+
+            df_result = df_result.append(
+                {"range_type": range_type, "M_eff": para_opt_kittel[0], 'damping': alpha, 'W0': para_opt_line[1], 'theta': args.theta, 'df': args.df, 'dn': args.dn}, ignore_index=True)
+        df_result.to_csv(str(args.dir) + "/" +
+                         thickness_dep_file, index=False)
+        print(df_result)
+        return ExitStatus.SUCCESS

--- a/src/STFMR/magnetization/__init__.py
+++ b/src/STFMR/magnetization/__init__.py
@@ -1,0 +1,1 @@
+from .core import MagnetizationFitting

--- a/src/STFMR/magnetization/core.py
+++ b/src/STFMR/magnetization/core.py
@@ -1,0 +1,56 @@
+import glob
+
+import scipy.optimize as sopt
+import pandas as pd
+import scipy.constants as sconst
+
+from rootcommand import CommonOption, RootCommand
+from uroboros import Command
+from uroboros.constants import ExitStatus
+
+from setting import *
+
+
+def fitfunc_satmag(x, M_s, K_s):
+    return M_s + K_s*x/(sconst.mu_0*M_s)
+
+
+class MagnetizationFitting(Command):
+    """Sub command of stfmr"""
+    name = 'satmag'
+    options = [CommonOption()]
+
+    short_description = 'Saturation Magnetization fitting for multiple samples'
+    long_description = 'Calculate and output saturation magnetization.'
+
+    def run(self, args):
+        file_list = glob.glob(str(args.dir) + '/**/' + thickness_dep_file)
+        df_list = []
+        for files in file_list:
+            df_list.append(pd.read_csv(files))
+        df = pd.concat(df_list, sort=False)
+        print(df)
+        df = df.set_index(["range_type"], drop=True)
+        df_result = pd.DataFrame(index=[],
+                                 columns=['range_type', 'M_s', 'K_s'])
+        for range_type in ["negative", "positive"]:
+           # load csv
+            df_val = df.loc[(range_type)]
+            M_eff = df_val["M_eff"].values.tolist()
+            d_f = df_val["df"].values.tolist()
+
+            # Kittel fitting
+            para_ini_satmag = [0.500, 3*10**(-10)]
+            [para_opt_satmag, cov] = sopt.curve_fit(
+                fitfunc_satmag, d_f, M_eff, para_ini_satmag)
+
+            df_result = df_result.append(
+                {"range_type": range_type, "M_s": para_opt_satmag[0], 'K_s': para_opt_satmag[1]*10**9}, ignore_index=True)
+
+            # xi_FMR
+            file_list = glob.glob('temp/*.txt')
+
+        df_result.to_csv(str(args.dir) + "/" +
+                         satmag_result_file, index=False)
+
+        return ExitStatus.SUCCESS

--- a/src/STFMR/rootcommand/__init__.py
+++ b/src/STFMR/rootcommand/__init__.py
@@ -1,0 +1,1 @@
+from .core import *

--- a/src/STFMR/rootcommand/core.py
+++ b/src/STFMR/rootcommand/core.py
@@ -1,0 +1,43 @@
+from setting import *
+from uroboros import Option, Command
+from uroboros.constants import ExitStatus
+from pathlib import Path
+
+
+class CommonOption(Option):
+
+    def build_option(self, parser):
+        # 共通するオプションを追加する
+        parser.add_argument(
+            'dir', type=Path, help="Target directory for ST-FMR analysis")
+        return parser
+
+        # 実行時にCommandの`run`より先に呼ばれる
+    def validate(self, args):
+        errors = []
+        # 指定したパスが存在しない場合エラーにする
+        if not args.dir.exists():
+            errors.append(Exception(
+                "Error! The specified directory '{}' does not exists.".format(args.dir)))
+        return errors
+
+
+class RootCommand(Command):
+    """Root command of your application"""
+    name = 'root'
+    long_description = 'This is a command for ST-FMR analysis'
+
+    def build_option(self, parser):
+        """Add optional arguments"""
+        parser.add_argument('--version', action='store_true',
+                            default=False, help='Print version')
+        return parser
+
+    def run(self, args):
+        """Your own script to run"""
+        if args.version:
+            print("{name} v{version}".format(
+                name=self.name, version='1.0.0'))
+        else:
+            self.print_help()
+        return ExitStatus.SUCCESS

--- a/src/STFMR/setting/__init__.py
+++ b/src/STFMR/setting/__init__.py
@@ -1,0 +1,1 @@
+from .core import *

--- a/src/STFMR/setting/core.py
+++ b/src/STFMR/setting/core.py
@@ -1,0 +1,3 @@
+curve_fitting_file = "curve_fit_result.csv"
+thickness_dep_file = "for_each_thickness_result.csv"
+satmag_result_file = "sample_result.csv"

--- a/src/STFMR/stfmr.py
+++ b/src/STFMR/stfmr.py
@@ -1,0 +1,22 @@
+from uroboros import Command
+from uroboros.constants import ExitStatus
+
+from rootcommand import CommonOption, RootCommand
+from curvefitting import CurveFitting, CurvePlotting
+from kittellinefitting import KittelLineFitting
+from magnetization import MagnetizationFitting
+from xifmr import XiFMRFitting
+from xifldl import XiFLDLFitting
+
+
+# Create command tree
+root_cmd = RootCommand()
+root_cmd.add_command(CurveFitting())
+root_cmd.add_command(CurvePlotting())
+root_cmd.add_command(KittelLineFitting())
+root_cmd.add_command(MagnetizationFitting())
+root_cmd.add_command(XiFMRFitting())
+root_cmd.add_command(XiFLDLFitting())
+
+if __name__ == '__main__':
+    exit(root_cmd.execute())

--- a/src/STFMR/xifldl/__init__.py
+++ b/src/STFMR/xifldl/__init__.py
@@ -1,0 +1,1 @@
+from .core import XiFLDLFitting

--- a/src/STFMR/xifldl/core.py
+++ b/src/STFMR/xifldl/core.py
@@ -1,0 +1,93 @@
+import glob
+import os
+
+import pandas as pd
+import scipy.constants as sconst
+import scipy.optimize as sopt
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+from rootcommand import CommonOption, RootCommand
+from uroboros import Command
+from uroboros.constants import ExitStatus
+
+from setting import *
+
+
+class XiFLDLFitting(Command):
+    """Sub command of stfmr"""
+    name = 'xifldl'
+    options = [CommonOption()]
+
+    short_description = 'Calculate xi_FL and xi_DL for multiple samples'
+    long_description = 'Calculate and output xi_DL and xi_FL.'
+
+    def run(self, args):
+        d_f = {
+            'negative': [],
+            'positive': []
+        }
+        d_n = {
+            'negative': [],
+            'positive': []
+        }
+        xi_FMR_inv = {
+            'negative': [],
+            'positive': []
+        }
+        df_satmag = pd.read_csv(str(args.dir) + "/" +
+                                satmag_result_file)
+        df_satmag = df_satmag.set_index(["range_type"], drop=True)
+        folder_list = glob.glob(str(args.dir) + '/**/')
+        for folders in folder_list:
+            thick_result = folders + thickness_dep_file
+            curve_result = folders + curve_fitting_file
+            if os.path.isfile(thick_result) and os.path.isfile(curve_result):
+                print(folders)
+                df_thick = pd.read_csv(thick_result)
+                df_thick = df_thick.set_index(["range_type"], drop=True)
+                df_curve = pd.read_csv(curve_result)
+                df_curve = df_curve.set_index(["range_type"], drop=True)
+                for range_type in ['negative', "positive"]:
+                    d_f[range_type].append(
+                        df_thick.loc[range_type]['df'] * 1e-9)
+                    d_n[range_type].append(
+                        df_thick.loc[range_type]['dn'] * 1e-9)
+                    xi_FMR_inv[range_type].append(
+                        1 / df_thick.loc[range_type]['xi_FMR_ave'])
+        for range_type in ['negative', "positive"]:
+            M_s = df_satmag.loc[range_type]['M_s']
+
+            d_arr = (1/(np.array(d_f[range_type]) *
+                        np.array(d_n[range_type]))).tolist()
+            para_ini = [0.01, 0.01]
+            print(xi_FMR_inv[range_type])
+            print(M_s)
+            print(d_arr)
+
+            Fontsize = 12
+            plt.plot(d_arr, xi_FMR_inv[range_type],
+                     marker='.', linewidth=0, label=range_type)
+
+            def fitfunc_xifmr(d_inv, xi_DL, xi_FL):
+                return (1 + sconst.hbar * xi_FL / (sconst.elementary_charge * M_s)) * d_inv / xi_DL
+
+            para, _ = sopt.curve_fit(
+                fitfunc_xifmr, d_arr, xi_FMR_inv[range_type], para_ini)
+            df_satmag.at[range_type, 'xi_DL'] = para[0]
+            df_satmag.at[range_type, 'xi_FL'] = para[1]
+        df_satmag.to_csv(str(args.dir) + "/" +
+                         satmag_result_file)
+        plt.legend(bbox_to_anchor=(0, 1), loc='upper left',
+                   borderaxespad=0, fontsize=Fontsize)
+        plt.xticks(fontsize=Fontsize)
+        plt.yticks(fontsize=Fontsize)
+        plt.grid(True)
+        plt.title("xi_FMR vs thickness")
+        plt.xlabel('1/df*dn (m^-2)', fontsize=Fontsize)
+        plt.ylabel('xi FMR^-1', fontsize=Fontsize)
+        plt.savefig(str(args.dir) +
+                    "/xi_FMR_result.png")
+
+        return ExitStatus.SUCCESS

--- a/src/STFMR/xifldl/core.py
+++ b/src/STFMR/xifldl/core.py
@@ -71,7 +71,7 @@ class XiFLDLFitting(Command):
                      marker='.', linewidth=0, label=range_type)
 
             def fitfunc_xifmr(d_inv, xi_DL, xi_FL):
-                return (1 + sconst.hbar * xi_FL / (sconst.elementary_charge * M_s)) * d_inv / xi_DL
+                return (1 + sconst.hbar * xi_FL / (sconst.elementary_charge * M_s) * d_inv) / xi_DL
 
             para, _ = sopt.curve_fit(
                 fitfunc_xifmr, d_arr, xi_FMR_inv[range_type], para_ini)

--- a/src/STFMR/xifmr/__init__.py
+++ b/src/STFMR/xifmr/__init__.py
@@ -1,0 +1,1 @@
+from .core import XiFMRFitting

--- a/src/STFMR/xifmr/core.py
+++ b/src/STFMR/xifmr/core.py
@@ -1,0 +1,61 @@
+import glob
+import os
+
+import pandas as pd
+import scipy.constants as sconst
+import numpy as np
+
+from rootcommand import CommonOption, RootCommand
+from uroboros import Command
+from uroboros.constants import ExitStatus
+
+from setting import *
+
+
+class XiFMRFitting(Command):
+    """Sub command of stfmr"""
+    name = 'xifmr'
+    options = [CommonOption()]
+
+    short_description = 'Calculate xi_FMR for multiple samples'
+    long_description = 'Calculate and output xi_FMR.'
+
+    def run(self, args):
+        df_satmag = pd.read_csv(str(args.dir) + "/" +
+                                satmag_result_file)
+        df_satmag = df_satmag.set_index(["range_type"], drop=True)
+        folder_list = glob.glob(str(args.dir) + '/**/')
+        for folders in folder_list:
+            thick_result = folders + thickness_dep_file
+            curve_result = folders + curve_fitting_file
+            if os.path.isfile(thick_result) and os.path.isfile(curve_result):
+                print(folders)
+                df_thick = pd.read_csv(thick_result)
+                df_thick = df_thick.set_index(["range_type"], drop=True)
+                df_curve = pd.read_csv(curve_result)
+                df_curve = df_curve.set_index(["range_type"], drop=True)
+                xi_FMR_list = {
+                    'negative': [],
+                    'positive': []
+                }
+                for range_type, M_s in [["negative", df_satmag.at['negative', 'M_s']], ["positive", df_satmag.at['positive', 'M_s']]]:
+                    d_f = df_thick.at[range_type, 'df']*1e-9
+                    d_n = df_thick.at[range_type, 'dn']*1e-9
+                    M_eff = df_thick.at[range_type, 'M_eff']
+                    df_curve_value = df_curve.loc[range_type]
+                    for index, row in df_curve_value.iterrows():
+                        h_res = row['h_res']
+                        sa_ratio = row['sym'] / row['asym']
+                        xi_FMR = sa_ratio*sconst.elementary_charge*M_s*d_f * \
+                            d_n * np.sqrt(1 + M_eff * 1000 /
+                                          h_res) / sconst.hbar
+                        df_curve.at[index, 'xi_FMR'] = xi_FMR
+                        xi_FMR_list[range_type].append(xi_FMR)
+                    # average and std of xi_FMR
+                    df_thick.at[range_type, 'xi_FMR_ave'] = np.mean(
+                        xi_FMR_list[range_type])
+                    df_thick.at[range_type, 'xi_FMR_std'] = np.std(
+                        xi_FMR_list[range_type])
+                df_curve.to_csv(curve_result)
+                df_thick.to_csv(thick_result)
+        return ExitStatus.SUCCESS


### PR DESCRIPTION
## Python code for ST-FMR analysis
:+1:PythonでST-FMR解析用のコードを書きました．
## Features
- [uroboros](https://github.com/pddg/uroboros)([著者のブログ](https://poyo.hatenablog.jp/entry/2019/07/14/000903))を使ったCLIアプリケーションです．コマンドラインから動作します．
## Usage
データのディレクトリ構造が
root/
├11/
│ ├12300mW-4.00GHz.lvm
│ ├12300mW-4.50GHz.lvm
│ ⋮
│ 
├21
└ 31
のようになっているとします．
### Curve fitting
```
python3 stfmr.py curve your_stfmr_data_directory
```
でsummetry部分とantisymmetry部分の波形のフィッティングを行います．結果はcurve_fit_result.csvに保存されます．
### Kittel & line fitting
```
python3 stfmr.py kittelline your_stfmr_data_directory theta df dn
```
でcurveでフィッティングしたデータを用いて有効磁場やダンピング係数，線幅の切片を計算します．結果はfor_each_thickness_result.csvに保存されます．
### Saturation magnetization
```
python3 stfmr.py satmag your_stfmr_root_directory
```
でkittellineで計算した有効磁化と膜厚を用いて飽和磁化とK_sを計算します．結果はsample_result.csvに保存されます．
### ξ_FMR
```
python3 stfmr.py xifmr your_stfmr_root_directory
```
でsatmagで計算した飽和磁化とcurveの計算結果を用いてξ_fmrを計算します．結果はcurve_fit_result.csvに保存されます．
### ξ_FL & ξ_DL
```
python3 stfmr.py xifldl your_stfmr_root_directory
```
でxifmrで計算したξ_FMRの膜厚依存性を用いてξ_FLとξ_DLを計算します（動作未確認）．

